### PR TITLE
Use arguments as files to read

### DIFF
--- a/eqn.h
+++ b/eqn.h
@@ -217,4 +217,5 @@ extern int e_columnsep;
 extern int e_baselinesep;
 extern int e_bodyheight;
 extern int e_bodydepth;
+extern FILE *e_fp;
 void def_set(char *name, int val);

--- a/src.c
+++ b/src.c
@@ -67,7 +67,7 @@ static void src_pop(void)
 
 static int src_stdin(void)
 {
-	int c = fgetc(stdin);
+	int c = fgetc(e_fp);
 	if (c == '\n')
 		lineno++;
 	return c;


### PR DESCRIPTION
It is very useful in scripts to have all
preprocessors accept both stdin and files
from arg.

This patch is very hacky. I may have missed
some important detail.